### PR TITLE
fixes in checker and samples with overlapping names. PROD_1_1

### DIFF
--- a/crab/PSet.py
+++ b/crab/PSet.py
@@ -7,7 +7,8 @@ process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring(),
 #	lumisToProcess=cms.untracked.VLuminosityBlockRange("254231:1-254231:24")
 )
 process.source.fileNames = [
-	'/store/data/Run2018D/SingleMuon/NANOAOD/Nano1June2019-v1/40000/98CBE3D1-4761-F24E-8007-2B2777551D2B.root'
+	'/store/data/Run2016D/SingleMuon/NANOAOD/Nano1June2019-v1/40000/FB2EEAE0-BD81-1043-BD77-80BB4273EB6D.root',
+#	'/store/data/Run2018D/SingleMuon/NANOAOD/Nano1June2019-v1/40000/98CBE3D1-4761-F24E-8007-2B2777551D2B.root',
 #	'../../NanoAOD/test/lzma.root' ##you can change only this line
 ]
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10))

--- a/crab/checker.py
+++ b/crab/checker.py
@@ -33,7 +33,7 @@ def checkModuleSettings(moduleSettings,datamc,year,era):
     if len(year_) == 5:
         era_ = year_[4]
         year_ = year_[0:4]
-    if datamc_ == datamc and year_ == str(year) and era_ == era:
+    if datamc_ == datamc and year_ == str(year) and (era_ == era or era_ ==''):
         return True
     else:
         raise Exception("ERROR in checkModuleSettings(%s, %s, %s, %s)"%(moduleSettings,datamc,year,era))

--- a/crab/crab_cfg_all.py
+++ b/crab/crab_cfg_all.py
@@ -5,7 +5,7 @@ from CRABClient.UserUtilities import config, getUsernameFromSiteDB
 
 config = Configuration()
 
-version = "PROD_1_0"
+version = "PROD_1_1"
 
 datasetToTest = [] ## if empty, run on all datasets
 #datasetToTest = ['/DYJetsToLL_M-105To160_TuneCP5_PSweights_13TeV-amcatnloFXFX-pythia8/RunIIAutumn18NanoAODv5-Nano1June2019_102X_upgrade2018_realistic_v19-v1/NANOAODSIM']
@@ -51,6 +51,7 @@ checkDatasets(["data2016", "mc2016", "data2017", "mc2017", "data2018", "mc2018"]
 
 from CRABAPI.RawCommand import crabCommand
 
+requestNames = set()
 if __name__ == '__main__':
     for datasets in [data2016, mc2016, data2017, mc2017, data2018, mc2018]:
         samples = datasets.keys()
@@ -65,10 +66,13 @@ if __name__ == '__main__':
                     config.Data.lumiMask = 'https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON_v1.txt'
                 if dataset == data2018 : 
                     config.Data.lumiMask = 'https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions18/13TeV/ReReco/Cert_314472-325175_13TeV_17SeptEarlyReReco2018ABC_PromptEraD_Collisions18_JSON.txt'
-                ext = ''
+		ext = ''
                 if "_ext" in dataset: 
                     ext = '_ext' + dataset.split("_ext")[1][0]
-                config.General.requestName = version + "_" + sample +  ext
+		requestName = version + "_" + sample +  ext
+		while requestName in requestNames:
+		    requestName = requestName+"_"	
+		config.General.requestName = requestName
                 config.Data.outputDatasetTag = version
                 print
                 print config.Data.inputDataset


### PR DESCRIPTION
Prod 1 0 ha crashato perche'
- il checker non funzionava con data2016 
- ci sono samples con due dataset (che non sono banali "ext*") che facevano crashare crab perche' usano lo stesso requestName in crab. (vedi https://github.com/gmandorl/nanoAOD-tools/blob/master/crab/datasets2016.py#L235-L238)

Fixato i bug, e lanciato PROD 1 1