### PR TITLE
Prod 11 1

### DIFF
--- a/crab/datasets2016AndreaV7.py
+++ b/crab/datasets2016AndreaV7.py
@@ -1,0 +1,259 @@
+data2016 = {
+"SingleMuonRun2016"     : [
+    #'/SingleMuon/Run2016B_ver1-Nano25Oct2019_ver1-v1/NANOAOD', # lumisections masked
+    '/SingleMuon/Run2016B_ver2-Nano25Oct2019_ver2-v1/NANOAOD',
+    '/SingleMuon/Run2016C-Nano25Oct2019-v1/NANOAOD',
+    '/SingleMuon/Run2016D-Nano25Oct2019-v1/NANOAOD',
+    '/SingleMuon/Run2016E-Nano25Oct2019-v1/NANOAOD',
+    '/SingleMuon/Run2016F-Nano25Oct2019-v1/NANOAOD',
+    '/SingleMuon/Run2016G-Nano25Oct2019-v1/NANOAOD',
+    '/SingleMuon/Run2016H-Nano25Oct2019-v1/NANOAOD'
+],
+}
+
+
+mc2016 = {
+
+
+#"DY105_2016AMCPY"     : [
+    #'/DYJetsToLL_M-105To160_TuneCP5_PSweights_13TeV-amcatnloFXFX-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM',
+    #'/DYJetsToLL_M-105To160_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7_ext1-v1/NANOAODSIM'
+#],
+#"DY105_2016MGPY"      : [
+    #'/DYJetsToLL_M-105To160_TuneCP5_PSweights_13TeV-madgraphMLM-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+#],
+#"DY105VBF_2016AMCPY"  : [
+    #'/DYJetsToLL_M-105To160_VBFFilter_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_VBFPostMGFilter_102X_mcRun2_asymptotic_v7_ext2-v1/NANOAODSIM'
+#],
+#"DY105VBF_2016MGPY"   : [
+    #'/DYJetsToLL_M-105To160_VBFFilter_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_VBFPostMGFilter_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+#],
+
+#"DY0J_2016AMCPY"  : [
+    #'/DYToLL_0J_13TeV-amcatnloFXFX-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7_ext1-v1/NANOAODSIM',
+    #'/DYToLL_0J_13TeV-amcatnloFXFX-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_backup_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+#],
+#"DY1J_2016AMCPY"  : [
+    #'/DYToLL_1J_13TeV-amcatnloFXFX-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7_ext1-v1/NANOAODSIM'
+#],
+##"DY2J_2016AMCPY"  : [
+    ##'/DYToLL_2J_13TeV-amcatnloFXFX-pythia8/nlu-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1-139-613263e16580a19441b112a234e25be6/USER',
+    ##'/DYToLL_2J_13TeV-amcatnloFXFX-pythia8/nlu-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3_ext1-v2-1384-613263e16580a19441b112a234e25be6/USER'
+##],
+##~ "DYTau_2016AMCPY" : [
+    ##~ ""
+##~ ],
+#"DYM50_2016AMCPY" : [
+    #'/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7_ext2-v1/NANOAODSIM'
+#],
+
+#"EWKZ105_2016MGHERWIG"     : [
+    #'/EWK_LLJJ_MLL_105-160_SM_5f_LO_TuneEEC5_13TeV-madgraph-herwigpp/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+#],
+#"EWKZ_2016MGHERWIG"        : [
+    #'/EWK_LLJJ_MLL-50_MJJ-120_13TeV-madgraph-herwigpp/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+#],
+#"EWKZ105_2016MGPY"         : [
+    #'/EWK_LLJJ_MLL_105-160_SM_5f_LO_TuneCUETP8M1_PSweights_13TeV-madgraph-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+#],
+#"EWKZ_2016MGPY"            : [
+    #'/EWK_LLJJ_MLL-50_MJJ-120_13TeV-madgraph-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+#],
+#"EWKZint_2016MGPY"         : [
+    #'/LLJJ_INT_SM_5f_LO_13TeV_madgraph-pythia8_TuneCUETP8M1/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7_ext1-v1/NANOAODSIM'
+#],
+
+
+#"STs_2016AMCPY"             : [
+    #'/ST_s-channel_4f_leptonDecays_13TeV_PSweights-amcatnlo-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM',
+    #'/ST_s-channel_4f_leptonDecays_TuneCP5_PSweights_13TeV-amcatnlo-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+#],
+#"STwtbar_2016POWPY"         : [
+    #'/ST_tW_antitop_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7_ext1-v1/NANOAODSIM', 
+    #'/ST_tW_antitop_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M2T4/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM',
+    #'/ST_tW_antitop_5f_inclusiveDecays_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+#],
+#"STwt_2016POWPY"            : [
+    #'/ST_tW_top_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7_ext1-v1/NANOAODSIM',
+    #'/ST_tW_top_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M2T4/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM',
+    #'/ST_tW_top_5f_inclusiveDecays_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+#],
+#"STtbar_2016POW_MADSPIN_PY" : [
+    #'/ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM',
+    #'/ST_t-channel_antitop_4f_inclusiveDecays_13TeV_PSweights-powhegV2-madspin/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+#],
+#"STt_2016POW_MADSPIN_PY"    : [
+    #'/ST_t-channel_top_4f_InclusiveDecays_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM',
+    #'/ST_t-channel_top_4f_inclusiveDecays_13TeV_PSweights-powhegV2-madspin/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+#],
+
+#"TT_2016POWPY"      : [
+    #'/TT_TuneCUETP8M2T4_13TeV-powheg-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM',
+    #'/TT_TuneCUETP8M2T4_13TeV-powheg-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v2/NANOAODSIM',
+    ##'/TT_TuneCUETP8M2T4_13TeV-powheg-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_backup_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+#],
+
+#"TT_2016POWHERWIG"      : [
+    #'/TT_TuneEE5C_13TeV-powheg-herwigpp/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7_ext3-v1/NANOAODSIM'
+#],
+#"TTlep_2016POWPY"   : [
+    #'/TTTo2L2Nu_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+#],
+#"TTsemi_2016POWPY"  : [
+    #"/TTToSemiLeptonic_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM"
+#],
+##"TTlep_2016MGPY"    : [
+    ##'/TTJets_DiLept_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/nlu-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2-1322-613263e16580a19441b112a234e25be6/USER',
+    ##'/TTJets_DiLept_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/nlu-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3_ext1-v2-1312-613263e16580a19441b112a234e25be6/USER'
+##],
+#"TThad_2016POWPY"   : [
+    #"/TTToHadronic_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM"
+#],
+
+
+
+#"W2J_2016AMCPY"  : [
+    #'/WToLNu_2J_13TeV-amcatnloFXFX-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7_ext4-v1/NANOAODSIM' #ne manca uno
+#],
+##"W1J_2016AMCPY"  : [
+    ##'/WToLNu_1J_13TeV-amcatnloFXFX-pythia8/nlu-RunIISummer16MiniAODv3-PUMoriond17_backup_94X_mcRun2_asymptotic_v3-v2-103-613263e16580a19441b112a234e25be6/USER'
+##],
+#"W0J_2016AMCPY"  : [
+    #'/WToLNu_0J_13TeV-amcatnloFXFX-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7_ext1-v1/NANOAODSIM',
+    #'/WToLNu_0J_13TeV-amcatnloFXFX-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_backup_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+#],
+
+
+#"WWdps_2016MGPY"             : [
+    #'/WWTo2L2Nu_DoubleScattering_13TeV-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+#],
+##"WWJJlnln_2016MGPY"          : [
+    ##'/WWJJToLNuLNu_EWK_13TeV-madgraph-pythia8/nlu-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1-127-613263e16580a19441b112a234e25be6/USER'
+##],
+#"WLLJJln_2016MG_MADSPIN_PY"  : [
+    #'/WLLJJ_WToLNu_EWK_TuneCUETP8M1_13TeV_madgraph-madspin-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+#],
+##"WWJJlnlnNoT_2016MGPY"       : [
+    ##'/WWJJToLNuLNu_EWK_noTop_13TeV-madgraph-pythia8/nlu-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1-126-613263e16580a19441b112a234e25be6/USER'
+##],
+
+
+#"WW2l2n_2016POWPY"          : [
+    #'/WWTo2L2Nu_13TeV-powheg/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+#],
+##"WWlnqq_2016AMC_MADSPIN_PY" : [
+    ##'/WWTo1L1Nu2Q_13TeV_amcatnloFXFX_madspin_pythia8/nlu-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2-112-613263e16580a19441b112a234e25be6/USER'
+##],
+
+
+
+#"WZ1l1n2q_2016POWPY"            : [
+    #'/WZToLNu2Q_13TeV_powheg_pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+#],
+##"WZ1l1n2q_2016AMCPY"            : [
+    ##'/WZTo1L1Nu2Q_13TeV_amcatnloFXFX_madspin_pythia8/nlu-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2-122-613263e16580a19441b112a234e25be6/USER'
+##],
+##"WZ1l3n_2016AMCPY"              : [
+    ##'/WZTo1L3Nu_13TeV_amcatnloFXFX_madspin_pythia8/nlu-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2-121-613263e16580a19441b112a234e25be6/USER'
+##],
+##"WZ2l2q_2016AMC_MADSPIN_PY"     : [
+    ##'/WZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8/nlu-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2-1203-613263e16580a19441b112a234e25be6/USER'#################################################
+##],
+#"WZ2l2n_2016AMC_MADSPIN_PY"     : [
+    #'/WZTo2Q2Nu_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+#],
+#"WZ3l1n_2016POWPY"              : [
+    #'/WZTo3LNu_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7_ext1-v1/NANOAODSIM'
+#],
+#"WZ3l1n_2016AMCPY"              : [
+    #'/WZTo3LNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+#],
+
+
+
+#"ZZ2l2q_2016POWPY"     : [
+    #'/ZZTo2L2Q_13TeV_powheg_pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+#],
+##"ZZ2l2q_2016AMCPY"     : [
+    ##'/ZZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8/nlu-RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1-115-613263e16580a19441b112a234e25be6/USER'
+##],
+#"ZZ2l2n_2016POWPY"    : [
+    ##"/ZZTo2L2Nu_13TeV_powheg_pythia8/RunIISummer16NanoAODv5-PUMoriond17_Nano1June2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM", 
+    #"/ZZTo2L2Q_13TeV_powheg_pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM"
+#],
+
+
+
+#"ZZ_2016AMCPY": [
+    #'/ZZ_TuneCUETP8M1_13TeV-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM',
+    #'/ZZ_TuneCUETP8M1_13TeV-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7_ext1-v1/NANOAODSIM'
+
+#],
+#"WZ_2016AMCPY": [
+    #'/WZ_TuneCUETP8M1_13TeV-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+#],
+#"WW_2016AMCPY": [
+    #'/WW_TuneCUETP8M1_13TeV-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM',
+    #'/WW_TuneCUETP8M1_13TeV-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7_ext1-v1/NANOAODSIM'
+#],
+
+
+
+
+
+
+"ggHmm_2016AMCPY"       : [
+    '/GluGluHToMuMu_M125_TuneCP5_PSweights_13TeV_amcatnloFXFX_pythia8/arizzi-RunIISummer16MiniAODv3_FSRNANO2016MCV7a_un2_asymptotic_v3-v1-847055a3cfe926d5839aa8480bbc55fd/USER'
+],
+"ggHmm_2016POWPY"       : [
+    '/GluGlu_HToMuMu_M125_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRNANO2016MCV7a_symptotic_v3_ext1-v2-847055a3cfe926d5839aa8480bbc55fd/USER',
+    '/GluGlu_HToMuMu_M125_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRNANO2016MCV7a_un2_asymptotic_v3-v2-847055a3cfe926d5839aa8480bbc55fd/USER'
+],
+
+
+
+"vbfHmm_2016POWPY"      : [
+    '/VBF_HToMuMu_M125_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRNANO2016MCV7a_symptotic_v3_ext1-v2-847055a3cfe926d5839aa8480bbc55fd/USER',
+    '/VBF_HToMuMu_M125_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRNANO2016MCV7a_un2_asymptotic_v3-v2-847055a3cfe926d5839aa8480bbc55fd/USER'
+],
+"vbfHmm_2016POWHERWIG"  : [
+    '/VBFHToMuMu_M-125_TuneEEC5_13TeV-powheg-herwigpp/arizzi-RunIISummer16MiniAODv3_FSRNANO2016MCV7a_un2_asymptotic_v3-v1-847055a3cfe926d5839aa8480bbc55fd/USER'
+],
+"vbfHmm_2016AMCPY"      : [
+    '/VBFHToMuMu_M125_TuneCP5_PSweights_13TeV_amcatnlo_pythia8/arizzi-RunIISummer16MiniAODv3_FSRNANO2016MCV7a_un2_asymptotic_v3-v1-847055a3cfe926d5839aa8480bbc55fd/USER'
+],
+"vbfHmm_2016AMCHERWIG"  : [
+    '/VBFHToMuMu_M-125_TuneEEC5_13TeV-amcatnlo-herwigpp/arizzi-RunIISummer16MiniAODv3_FSRNANO2016MCV7a_un2_asymptotic_v3-v1-847055a3cfe926d5839aa8480bbc55fd/USER'
+],
+
+
+
+
+
+
+#"zHmm_2016POWPY"        : [
+    #'/ZH_HToMuMu_M125_13TeV_powheg_pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM',
+    #'/ZH_HToMuMu_ZToAll_M125_TuneCP5_PSweights_13TeV_powheg_pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+#],
+#"ttHmm_2016POWPY"       : [
+    #'/ttHToMuMu_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+#],
+#"WplusHmm_2016POWPY"    : [
+    #'/WplusH_HToMuMu_WToAll_M125_TuneCP5_PSweights_13TeV_powheg_pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+#],
+#"WminusHmm_2016POWPY"   : [
+    #'/WminusH_HToMuMu_WToAll_M125_TuneCP5_PSweights_13TeV_powheg_pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+#],
+##"vbfHtautau_2016POWPY"  : [
+    ##"/VBFHToTauTau_M125_13TeV_powheg_pythia8/RunIISummer16NanoAODv5-PUMoriond17_Nano1June2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM"
+##],
+##"bbHmm_2016AMCPY"  : [
+    ##"/bbHToMuMu_M-125_4FS_yb2_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer16NanoAODv5-PUMoriond17_Nano1June2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM"
+##],
+}
+
+
+
+
+
+

--- a/crab/datasets2016NANOv6.py
+++ b/crab/datasets2016NANOv6.py
@@ -1,0 +1,257 @@
+data2016 = {
+"SingleMuonRun2016"     : [
+    #'/SingleMuon/Run2016B_ver1-Nano25Oct2019_ver1-v1/NANOAOD', # lumisections masked
+    '/SingleMuon/Run2016B_ver2-Nano25Oct2019_ver2-v1/NANOAOD',
+    '/SingleMuon/Run2016C-Nano25Oct2019-v1/NANOAOD',
+    '/SingleMuon/Run2016D-Nano25Oct2019-v1/NANOAOD',
+    '/SingleMuon/Run2016E-Nano25Oct2019-v1/NANOAOD',
+    '/SingleMuon/Run2016F-Nano25Oct2019-v1/NANOAOD',
+    '/SingleMuon/Run2016G-Nano25Oct2019-v1/NANOAOD',
+    '/SingleMuon/Run2016H-Nano25Oct2019-v1/NANOAOD'
+],
+}
+
+mc2016 = {
+
+
+"DY105_2016AMCPY"     : [
+    '/DYJetsToLL_M-105To160_TuneCP5_PSweights_13TeV-amcatnloFXFX-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM',
+    '/DYJetsToLL_M-105To160_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7_ext1-v1/NANOAODSIM'
+],
+"DY105_2016MGPY"      : [
+    '/DYJetsToLL_M-105To160_TuneCP5_PSweights_13TeV-madgraphMLM-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+"DY105VBF_2016AMCPY"  : [
+    '/DYJetsToLL_M-105To160_VBFFilter_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_VBFPostMGFilter_102X_mcRun2_asymptotic_v7_ext2-v1/NANOAODSIM',
+    '/DYJetsToLL_M-105To160_VBFFilter_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_VBFPostMGFilter_102X_mcRun2_asymptotic_v7_ext1-v1/NANOAODSIM'
+],
+"DY105VBF_2016MGPY"   : [
+    '/DYJetsToLL_M-105To160_VBFFilter_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_VBFPostMGFilter_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+
+"DY0J_2016AMCPY"  : [
+    '/DYToLL_0J_13TeV-amcatnloFXFX-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7_ext1-v1/NANOAODSIM',
+    '/DYToLL_0J_13TeV-amcatnloFXFX-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_backup_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+"DY1J_2016AMCPY"  : [
+    '/DYToLL_1J_13TeV-amcatnloFXFX-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7_ext1-v1/NANOAODSIM',
+    '/DYToLL_1J_13TeV-amcatnloFXFX-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_backup_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+"DY2J_2016AMCPY"  : [
+    '/DYToLL_2J_13TeV-amcatnloFXFX-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM',
+    '/DYToLL_2J_13TeV-amcatnloFXFX-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7_ext1-v1/NANOAODSIM'
+],
+#~ "DYTau_2016AMCPY" : [
+    #~ ""
+#~ ],
+"DYM50_2016AMCPY" : [
+    '/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7_ext2-v1/NANOAODSIM'
+],
+
+"EWKZ105_2016MGHERWIG"     : [
+    '/EWK_LLJJ_MLL_105-160_SM_5f_LO_TuneEEC5_13TeV-madgraph-herwigpp/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+"EWKZ_2016MGHERWIG"        : [
+    '/EWK_LLJJ_MLL-50_MJJ-120_13TeV-madgraph-herwigpp/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+"EWKZ105_2016MGPY"         : [
+    '/EWK_LLJJ_MLL_105-160_SM_5f_LO_TuneCUETP8M1_PSweights_13TeV-madgraph-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+"EWKZ_2016MGPY"            : [
+    '/EWK_LLJJ_MLL-50_MJJ-120_13TeV-madgraph-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+"EWKZint_2016MGPY"         : [
+    '/LLJJ_INT_SM_5f_LO_13TeV_madgraph-pythia8_TuneCUETP8M1/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7_ext1-v1/NANOAODSIM'
+],
+
+
+"STs_2016AMCPY"             : [
+    '/ST_s-channel_4f_leptonDecays_13TeV_PSweights-amcatnlo-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM',
+    '/ST_s-channel_4f_leptonDecays_TuneCP5_PSweights_13TeV-amcatnlo-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+"STwtbar_2016POWPY"         : [
+    '/ST_tW_antitop_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7_ext1-v1/NANOAODSIM', 
+    '/ST_tW_antitop_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M2T4/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM',
+    '/ST_tW_antitop_5f_inclusiveDecays_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+"STwt_2016POWPY"            : [
+    '/ST_tW_top_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7_ext1-v1/NANOAODSIM',
+    '/ST_tW_top_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M2T4/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM',
+    '/ST_tW_top_5f_inclusiveDecays_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+"STtbar_2016POW_MADSPIN_PY" : [
+    '/ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM',
+    '/ST_t-channel_antitop_4f_inclusiveDecays_13TeV_PSweights-powhegV2-madspin/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+"STt_2016POW_MADSPIN_PY"    : [
+    '/ST_t-channel_top_4f_InclusiveDecays_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM',
+    '/ST_t-channel_top_4f_inclusiveDecays_13TeV_PSweights-powhegV2-madspin/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+
+"TT_2016POWPY"      : [
+    '/TT_TuneCUETP8M2T4_13TeV-powheg-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM',
+    '/TT_TuneCUETP8M2T4_13TeV-powheg-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v2/NANOAODSIM',
+    #'/TT_TuneCUETP8M2T4_13TeV-powheg-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_backup_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+
+"TT_2016POWHERWIG"      : [
+    '/TT_TuneEE5C_13TeV-powheg-herwigpp/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7_ext3-v1/NANOAODSIM'
+],
+"TTlep_2016POWPY"   : [
+    '/TTTo2L2Nu_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+"TTsemi_2016POWPY"  : [
+    "/TTToSemiLeptonic_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM"
+],
+"TTlep_2016MGPY"    : [
+    '/TTJets_DiLept_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM',
+    '/TTJets_DiLept_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7_ext1-v1/NANOAODSIM'
+],
+"TThad_2016POWPY"   : [
+    "/TTToHadronic_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM"
+],
+
+
+
+"W2J_2016AMCPY"  : [
+    '/WToLNu_2J_13TeV-amcatnloFXFX-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7_ext4-v1/NANOAODSIM' #ne manca uno
+],
+"W1J_2016AMCPY"  : [
+    '/WToLNu_1J_13TeV-amcatnloFXFX-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_backup_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+"W0J_2016AMCPY"  : [
+    '/WToLNu_0J_13TeV-amcatnloFXFX-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7_ext1-v1/NANOAODSIM',
+    '/WToLNu_0J_13TeV-amcatnloFXFX-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_backup_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+
+
+"WWdps_2016MGPY"             : [
+    '/WWTo2L2Nu_DoubleScattering_13TeV-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+"WWJJlnln_2016MGPY"          : [
+    '/WWJJToLNuLNu_EWK_13TeV-madgraph-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+"WLLJJln_2016MG_MADSPIN_PY"  : [
+    '/WLLJJ_WToLNu_EWK_TuneCUETP8M1_13TeV_madgraph-madspin-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+"WWJJlnlnNoT_2016MGPY"       : [
+    '/WWJJToLNuLNu_EWK_noTop_13TeV-madgraph-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+
+
+"WW2l2n_2016POWPY"          : [
+    '/WWTo2L2Nu_13TeV-powheg/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+"WWlnqq_2016AMC_MADSPIN_PY" : [
+    '/WWTo1L1Nu2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+
+
+
+"WZ1l1n2q_2016POWPY"            : [
+    '/WZToLNu2Q_13TeV_powheg_pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+"WZ1l1n2q_2016AMCPY"            : [
+    '/WZTo1L1Nu2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+"WZ1l3n_2016AMCPY"              : [
+    '/WZTo1L3Nu_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+"WZ2l2q_2016AMC_MADSPIN_PY"     : [
+    '/WZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'#################################################
+],
+"WZ2l2n_2016AMC_MADSPIN_PY"     : [
+    '/WZTo2Q2Nu_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+"WZ3l1n_2016POWPY"              : [
+    '/WZTo3LNu_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7_ext1-v1/NANOAODSIM'
+],
+"WZ3l1n_2016AMCPY"              : [
+    '/WZTo3LNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+
+
+
+"ZZ2l2q_2016POWPY"     : [
+    '/ZZTo2L2Q_13TeV_powheg_pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+"ZZ2l2q_2016AMCPY"     : [
+    '/ZZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+"ZZ2l2n_2016POWPY"    : [
+    #"/ZZTo2L2Nu_13TeV_powheg_pythia8/RunIISummer16NanoAODv5-PUMoriond17_Nano1June2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM", 
+    "/ZZTo2L2Q_13TeV_powheg_pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM"
+],
+
+
+
+"ZZ_2016AMCPY": [
+    '/ZZ_TuneCUETP8M1_13TeV-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM',
+    '/ZZ_TuneCUETP8M1_13TeV-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7_ext1-v1/NANOAODSIM'
+
+],
+"WZ_2016AMCPY": [
+    '/WZ_TuneCUETP8M1_13TeV-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+"WW_2016AMCPY": [
+    '/WW_TuneCUETP8M1_13TeV-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM',
+    '/WW_TuneCUETP8M1_13TeV-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7_ext1-v1/NANOAODSIM'
+],
+
+"ggHmm_2016AMCPY"       : [
+    '/GluGluHToMuMu_M125_TuneCP5_PSweights_13TeV_amcatnloFXFX_pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+"ggHmm_2016POWPY"       : [
+    '/GluGlu_HToMuMu_M125_13TeV_powheg_pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7_ext1-v1/NANOAODSIM',
+    '/GluGluHToMuMu_M-125_TuneCP5_PSweights_13TeV_powheg_pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+
+
+
+"vbfHmm_2016POWPY"      : [
+    '/VBF_HToMuMu_M125_13TeV_powheg_pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7_ext1-v1/NANOAODSIM',
+    '/VBFHToMuMu_M-125_TuneCP5_PSweights_13TeV_powheg_pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+"vbfHmm_2016POWHERWIG"  : [
+    '/VBFHToMuMu_M-125_TuneEEC5_13TeV-powheg-herwigpp/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+"vbfHmm_2016AMCPY"      : [
+    '/VBFHToMuMu_M125_TuneCP5_PSweights_13TeV_amcatnlo_pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+"vbfHmm_2016AMCHERWIG"  : [
+    '/VBFHToMuMu_M-125_TuneEEC5_13TeV-amcatnlo-herwigpp/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+
+
+"zHmm_2016POWPY"        : [
+    '/ZH_HToMuMu_M125_13TeV_powheg_pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM',
+    '/ZH_HToMuMu_ZToAll_M125_TuneCP5_PSweights_13TeV_powheg_pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+"ttHmm_2016POWPY"       : [
+    '/ttHToMuMu_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+"WplusHmm_2016POWPY"    : [
+    '/WplusH_HToMuMu_WToAll_M125_TuneCP5_PSweights_13TeV_powheg_pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+"WminusHmm_2016POWPY"   : [
+    '/WminusH_HToMuMu_WToAll_M125_TuneCP5_PSweights_13TeV_powheg_pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM'
+],
+"vbfHtautau_2016POWPY"  : [
+    "/VBFHToTauTau_M125_13TeV_powheg_pythia8/RunIISummer16NanoAODv5-PUMoriond17_Nano1June2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM"
+],
+"bbHmm_2016AMCPY"  : [
+    "/bbHToMuMu_M-125_4FS_yb2_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer16NanoAODv5-PUMoriond17_Nano1June2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM"
+],
+}
+
+
+
+
+
+
+
+
+
+
+
+

--- a/crab/datasets2016andreaGeoFit.py
+++ b/crab/datasets2016andreaGeoFit.py
@@ -1,0 +1,50 @@
+data2016 = {
+"SingleMuonRun2016"     : [
+],
+}
+
+
+
+mc2016 = {
+"ggHmm_2016AMCPY"       : [
+      #  '/GluGluHToMuMu_M-125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRNANO2016MCV8a_un2_asymptotic_v3-v1-402030b838330283a01886ce39c7d12e/USER',
+    '/GluGluHToMuMu_M125_TuneCP5_PSweights_13TeV_amcatnloFXFX_pythia8/arizzi-RunIISummer16MiniAODv3_FSRNANO2016MCV8c_un2_asymptotic_v3-v1-402030b838330283a01886ce39c7d12e/USER'
+],
+"ggHmm_2016AMCTuneCP5downPY"       : [
+    '/GluGluHToMuMu_M125_TuneCP5down_PSweights_13TeV_amcatnloFXFX_pythia8/arizzi-RunIISummer16MiniAODv3_FSRNANO2016MCV8a_un2_asymptotic_v3-v1-402030b838330283a01886ce39c7d12e/USER'
+],
+"ggHmm_2016AMCTuneCP5upPY"       : [
+    '/GluGluHToMuMu_M125_TuneCP5up_PSweights_13TeV_amcatnloFXFX_pythia8/arizzi-RunIISummer16MiniAODv3_FSRNANO2016MCV8a_un2_asymptotic_v3-v1-402030b838330283a01886ce39c7d12e/USER',
+],
+
+"ggHmm_2016POWPY"       : [
+    '/GluGlu_HToMuMu_M125_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRNANO2016MCV8a_symptotic_v3_ext1-v2-402030b838330283a01886ce39c7d12e/USER',
+    '/GluGlu_HToMuMu_M125_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRNANO2016MCV8a_un2_asymptotic_v3-v2-402030b838330283a01886ce39c7d12e/USER',
+],
+
+"vbfHmm_2016POWPY"      : [
+    '/VBFHToMuMu_M-125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRNANO2016MCV8a_un2_asymptotic_v3-v1-402030b838330283a01886ce39c7d12e/USER',
+    '/VBF_HToMuMu_M125_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRNANO2016MCV8a_symptotic_v3_ext1-v2-402030b838330283a01886ce39c7d12e/USER',
+    '/VBF_HToMuMu_M125_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRNANO2016MCV8a_un2_asymptotic_v3-v2-402030b838330283a01886ce39c7d12e/USER',
+],
+
+"vbfHmm_2016POWHERWIG"  : [
+    '/VBFHToMuMu_M-125_TuneEEC5_13TeV-powheg-herwigpp/arizzi-RunIISummer16MiniAODv3_FSRNANO2016MCV8a_un2_asymptotic_v3-v1-402030b838330283a01886ce39c7d12e/USER',
+],
+
+"vbfHmm_2016AMCPY"      : [
+    '/VBFHToMuMu_M125_TuneCP5_PSweights_13TeV_amcatnlo_pythia8/arizzi-RunIISummer16MiniAODv3_FSRNANO2016MCV8a_un2_asymptotic_v3-v1-402030b838330283a01886ce39c7d12e/USER',
+],
+
+"vbfHmm_2016AMCHERWIG"  : [
+    '/VBFHToMuMu_M-125_TuneEEC5_13TeV-amcatnlo-herwigpp/arizzi-RunIISummer16MiniAODv3_FSRNANO2016MCV8a_un2_asymptotic_v3-v1-402030b838330283a01886ce39c7d12e/USER',
+],
+
+}
+
+
+
+
+
+
+

--- a/crab/datasets2017Andrea.py
+++ b/crab/datasets2017Andrea.py
@@ -1,17 +1,17 @@
 data2017 = {
 "SingleMuonRun2017"     : [
-    "/SingleMuon/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdData2017_NANOV4_un2017F-31Mar2018-v1-fca2a3a20fe9002e1dc7c971a0424999/USER",
-    "/SingleMuon/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdData2017_NANOV4_un2017E-31Mar2018-v1-fca2a3a20fe9002e1dc7c971a0424999/USER",
-    "/SingleMuon/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdData2017_NANOV4_un2017D-31Mar2018-v1-fca2a3a20fe9002e1dc7c971a0424999/USER",
-    "/SingleMuon/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdData2017_NANOV4_un2017C-31Mar2018-v1-fca2a3a20fe9002e1dc7c971a0424999/USER",
-    "/SingleMuon/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdData2017_NANOV4_un2017B-31Mar2018-v1-fca2a3a20fe9002e1dc7c971a0424999/USER",
+    #"/SingleMuon/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdData2017_NANOV4_un2017F-31Mar2018-v1-fca2a3a20fe9002e1dc7c971a0424999/USER",
+    #"/SingleMuon/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdData2017_NANOV4_un2017E-31Mar2018-v1-fca2a3a20fe9002e1dc7c971a0424999/USER",
+    #"/SingleMuon/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdData2017_NANOV4_un2017D-31Mar2018-v1-fca2a3a20fe9002e1dc7c971a0424999/USER",
+    #"/SingleMuon/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdData2017_NANOV4_un2017C-31Mar2018-v1-fca2a3a20fe9002e1dc7c971a0424999/USER",
+    #"/SingleMuon/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdData2017_NANOV4_un2017B-31Mar2018-v1-fca2a3a20fe9002e1dc7c971a0424999/USER",
 ],
 }
 
 #/DYJetsToLL_M-105To160_TuneCP5_PSweights_13TeV-amcatnloFXFX-pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4i_017_realistic_v14-v1-35a58109e00c38928fe6fe04f08bafb3/USER
 
 mc2017 = {'DY0J_2017AMCPY': ['/DYJetsToLL_0J_TuneCP5_13TeV-amcatnloFXFX-pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4b_017_realistic_v14-v1-35a58109e00c38928fe6fe04f08bafb3/USER'],
- 'DY105VBF_2017AMCPY': ['/DYJetsToLL_M-105To160_VBFFilter_TuneCP5_PSweights_13TeV-amcatnloFXFX-pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4b_ealistic_v14_ext1-v1-35a58109e00c38928fe6fe04f08bafb3/USER''/DYJetsToLL_M-105To160_VBFFilter_TuneCP5_13TeV-amcatnloFXFX-pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4f_017_realistic_v14-v2-35a58109e00c38928fe6fe04f08bafb3/USER',
+ 'DY105VBF_2017AMCPY': ['/DYJetsToLL_M-105To160_VBFFilter_TuneCP5_PSweights_13TeV-amcatnloFXFX-pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4b_ealistic_v14_ext1-v1-35a58109e00c38928fe6fe04f08bafb3/USER','/DYJetsToLL_M-105To160_VBFFilter_TuneCP5_13TeV-amcatnloFXFX-pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4f_017_realistic_v14-v2-35a58109e00c38928fe6fe04f08bafb3/USER',
 ],
  'DY105VBF_2017MGPY': ['/DYJetsToLL_M-105To160_VBFFilter_TuneCP5_13TeV-madgraphMLM-pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4b_017_realistic_v14-v2-35a58109e00c38928fe6fe04f08bafb3/USER'],
  'DY105_2017AMCPY': [  '/DYJetsToLL_M-105To160_TuneCP5_PSweights_13TeV-amcatnloFXFX-pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4i_017_realistic_v14-v1-35a58109e00c38928fe6fe04f08bafb3/USER',
@@ -22,6 +22,7 @@ mc2017 = {'DY0J_2017AMCPY': ['/DYJetsToLL_0J_TuneCP5_13TeV-amcatnloFXFX-pythia8/
  'DYM50_2017AMCPY': ['/DYJetsToLL_M-50_VBFFilter_TuneCP5_PSweights_13TeV-amcatnloFXFX-pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4a_017_realistic_v14-v1-35a58109e00c38928fe6fe04f08bafb3/USER',  ],
  'DYTau_2017AMCPY': [None],
  'EWKZ105_2017MGHERWIG': ['/EWK_LLJJ_MLL_105-160_SM_5f_LO_TuneCH3_13TeV-madgraph-herwig7/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4a_017_realistic_v14-v1-35a58109e00c38928fe6fe04f08bafb3/USER'],
+ 'EWKZ105_2017MGPY': ['/EWK_LLJJ_MLL_105-160_SM_5f_LO_TuneCP5_PSweights_13TeV-madgraph-pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV8c_017_realistic_v14-v1-ef4ff047883fc7dcd360f5fd3b961f3e/USER'],
  'EWKZ_2017MGHERWIG': [ '/EWK_LLJJ_MLL-50_MJJ-120_TuneCH3_PSweights_13TeV-madgraph-herwig7/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4f_017_realistic_v14-v1-35a58109e00c38928fe6fe04f08bafb3/USER',
 ],
  'EWKZ_2017MGPY': ['/EWK_LLJJ_MLL-50_MJJ-120_TuneCP5_13TeV-madgraph-pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4a_017_realistic_v14-v1-35a58109e00c38928fe6fe04f08bafb3/USER'],
@@ -83,19 +84,19 @@ mc2017 = {'DY0J_2017AMCPY': ['/DYJetsToLL_0J_TuneCP5_13TeV-amcatnloFXFX-pythia8/
 "/ZZTo4L_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4a_017_realistic_v14-v2-35a58109e00c38928fe6fe04f08bafb3/USER",
 "/ZZTo4L_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4a_017_realistic_v14-v1-35a58109e00c38928fe6fe04f08bafb3/USER"],
  'ZZ_2017AMCPY': ['/ZZ_TuneCP5_13TeV-pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4a_017_realistic_v14-v1-35a58109e00c38928fe6fe04f08bafb3/USER'],
- 'ggHmm_2017AMCPY': ['/GluGluHToMuMu_M125_13TeV_amcatnloFXFX_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4a_017_realistic_v14-v1-35a58109e00c38928fe6fe04f08bafb3/USER'],
- 'ggHmm_2017AMCPY2': [None],
- 'ggHmm_2017POWPY': [None],
- 'ggHmm_2017POWPY2': [None,
-                      '/GluGluHToMuMu_M-125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4_ealistic_v14_ext1-v1-35a58109e00c38928fe6fe04f08bafb3/USER'],
- 'ttHmm_2017POWPY': ['/ttHToMuMu_M125_TuneCP5_13TeV-powheg-pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4_017_realistic_v14-v3-35a58109e00c38928fe6fe04f08bafb3/USER',
- '/ttHToMuMu_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4_017_realistic_v14-v1-35a58109e00c38928fe6fe04f08bafb3/USER'],
- 'vbfHmm_2017AMCHERWIG': ['/VBFHToMuMu_M-125_TuneEEC5_13TeV-powheg-herwigpp/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4b_017_realistic_v14-v1-35a58109e00c38928fe6fe04f08bafb3/USER'],
- 'vbfHmm_2017AMCPY': ['/VBFHToMuMu_M125_13TeV_amcatnlo_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4b_017_realistic_v14-v1-35a58109e00c38928fe6fe04f08bafb3/USER'],
- 'vbfHmm_2017POWPY': ['/VBFHToMuMu_M-125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4e_017_realistic_v14-v1-35a58109e00c38928fe6fe04f08bafb3/USER'],
- 'vbfHtautau_2017POWPY': ['/VBFHToTauTau_M125_13TeV_amcatnloFXFX_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4_017_realistic_v14-v1-35a58109e00c38928fe6fe04f08bafb3/USER'],
- 'zHmm_2017POWPY': ['/ZH_HToMuMu_ZToAll_M125_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4a_017_realistic_v14-v1-35a58109e00c38928fe6fe04f08bafb3/USER'],
- 'others_2017': [
- ],
+ #'ggHmm_2017AMCPY': ['/GluGluHToMuMu_M125_13TeV_amcatnloFXFX_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4a_017_realistic_v14-v1-35a58109e00c38928fe6fe04f08bafb3/USER'],
+ #'ggHmm_2017AMCPY2': [None],
+ #'ggHmm_2017POWPY': [None],
+ #'ggHmm_2017POWPY2': [None,
+                      #'/GluGluHToMuMu_M-125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4_ealistic_v14_ext1-v1-35a58109e00c38928fe6fe04f08bafb3/USER'],
+ #'ttHmm_2017POWPY': ['/ttHToMuMu_M125_TuneCP5_13TeV-powheg-pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4_017_realistic_v14-v3-35a58109e00c38928fe6fe04f08bafb3/USER',
+ #'/ttHToMuMu_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4_017_realistic_v14-v1-35a58109e00c38928fe6fe04f08bafb3/USER'],
+ #'vbfHmm_2017AMCHERWIG': ['/VBFHToMuMu_M-125_TuneEEC5_13TeV-powheg-herwigpp/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4b_017_realistic_v14-v1-35a58109e00c38928fe6fe04f08bafb3/USER'],
+ #'vbfHmm_2017AMCPY': ['/VBFHToMuMu_M125_13TeV_amcatnlo_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4b_017_realistic_v14-v1-35a58109e00c38928fe6fe04f08bafb3/USER'],
+ #'vbfHmm_2017POWPY': ['/VBFHToMuMu_M-125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4e_017_realistic_v14-v1-35a58109e00c38928fe6fe04f08bafb3/USER'],
+ #'vbfHtautau_2017POWPY': ['/VBFHToTauTau_M125_13TeV_amcatnloFXFX_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4_017_realistic_v14-v1-35a58109e00c38928fe6fe04f08bafb3/USER'],
+ #'zHmm_2017POWPY': ['/ZH_HToMuMu_ZToAll_M125_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4a_017_realistic_v14-v1-35a58109e00c38928fe6fe04f08bafb3/USER'],
+ #'others_2017': [
+ #],
  }
 

--- a/crab/datasets2017AndreaV7.py
+++ b/crab/datasets2017AndreaV7.py
@@ -1,0 +1,65 @@
+data2017 = {
+"SingleMuonRun2017"     : [
+    "/SingleMuon/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdData2017_NANOV4_un2017B-31Mar2018-v1-fca2a3a20fe9002e1dc7c971a0424999/USER", 
+    "/SingleMuon/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdData2017_NANOV4_un2017C-31Mar2018-v1-fca2a3a20fe9002e1dc7c971a0424999/USER",
+    "/SingleMuon/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdData2017_NANOV4_un2017D-31Mar2018-v1-fca2a3a20fe9002e1dc7c971a0424999/USER", 
+    "/SingleMuon/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdData2017_NANOV4_un2017E-31Mar2018-v1-fca2a3a20fe9002e1dc7c971a0424999/USER", 
+    "/SingleMuon/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdData2017_NANOV4_un2017F-31Mar2018-v1-fca2a3a20fe9002e1dc7c971a0424999/USER"
+],
+}
+
+
+mc2017 = {
+
+"ggHmm_2017AMCPY"       : [
+    '/GluGluHToMuMu_M-125_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV7a_017_realistic_v14-v1-45be640e722e9a1c4c41041a9d219192/USER',
+    '/GluGluHToMuMu_M-125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV7a_017_realistic_v14-v1-45be640e722e9a1c4c41041a9d219192/USER',
+    '/GluGluHToMuMu_M-125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV7a_ealistic_v14_ext1-v1-45be640e722e9a1c4c41041a9d219192/USER'
+],
+"ggHmm_2017POWPY"       : [
+    '/GluGluHToMuMu_M125_13TeV_amcatnloFXFX_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV7a_017_realistic_v14-v1-45be640e722e9a1c4c41041a9d219192/USER',
+    '/GluGluHToMuMu_M125_TuneCP5_PSweights_13TeV_amcatnloFXFX_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV7a_017_realistic_v14-v1-45be640e722e9a1c4c41041a9d219192/USER',
+    '/GluGluHToMuMu_M125_TuneCP5_PSweights_13TeV_amcatnloFXFX_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV7a_ealistic_v14_ext1-v1-45be640e722e9a1c4c41041a9d219192/USER'
+],
+
+
+"vbfHmm_2017POWPY"      : [
+    '/VBFHToMuMu_M-125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV7a_017_realistic_v14-v1-45be640e722e9a1c4c41041a9d219192/USER'
+],
+"vbfHmm_2017AMCPY"      : [
+    '/VBFHToMuMu_M125_13TeV_amcatnlo_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV7a_017_realistic_v14-v1-45be640e722e9a1c4c41041a9d219192/USER',
+    '/VBFHToMuMu_M125_TuneCP5_PSweights_13TeV_amcatnlo_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV7a_017_realistic_v14-v1-45be640e722e9a1c4c41041a9d219192/USER',
+    '/VBFHToMuMu_M125_TuneCP5_PSweights_13TeV_amcatnlo_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV7a_ealistic_v14_ext1-v1-45be640e722e9a1c4c41041a9d219192/USER'
+],
+"vbfHmm_2017AMCHERWIG"  : [
+    '/VBFHToMuMu_M-125_TuneEEC5_13TeV-amcatnlo-herwigpp/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV7a_017_realistic_v14-v1-45be640e722e9a1c4c41041a9d219192/USER'
+],
+"vbfHmm_2017POWHERWIG"  : [
+    '/VBFHToMuMu_M-125_TuneEEC5_13TeV-powheg-herwigpp/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV7a_017_realistic_v14-v1-45be640e722e9a1c4c41041a9d219192/USER'
+],
+
+"zHmm_2017POWPY"        : [
+    '/ZH_HToMuMu_ZToAll_M125_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV7a_017_realistic_v14-v1-45be640e722e9a1c4c41041a9d219192/USER'
+],
+"ttHmm_2017POWPY"       : [
+    '/ttHToMuMu_M125_TuneCP5_13TeV-powheg-pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV7a_017_realistic_v14-v3-45be640e722e9a1c4c41041a9d219192/USER',
+    '/ttHToMuMu_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV7a_017_realistic_v14-v1-45be640e722e9a1c4c41041a9d219192/USER'
+],
+"WplusHmm_2017POWPY"    : [
+    '/WplusH_HToMuMu_WToAll_M125_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV7a_017_realistic_v14-v3-45be640e722e9a1c4c41041a9d219192/USER'
+],
+"WminusHmm_2017POWPY"   : [
+    '/WminusH_HToMuMu_WToAll_M125_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV7a_017_realistic_v14-v1-45be640e722e9a1c4c41041a9d219192/USER'
+],
+#"vbfHtautau_2017POWPY"  : [
+    #'/VBFHToTauTau_M125_13TeV_amcatnloFXFX_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4_017_realistic_v14-v1-35a58109e00c38928fe6fe04f08bafb3/USER'
+#],
+}
+
+
+
+
+
+
+
+

--- a/crab/datasets2017andreaGeoFit.py
+++ b/crab/datasets2017andreaGeoFit.py
@@ -1,0 +1,77 @@
+data2017 = {
+"SingleMuonRun2016"     : [
+],
+}
+
+
+
+mc2017 = {
+"ggHmm_2017AMCPY"       : [
+#    '/GluGluHToMuMu_M125_13TeV_amcatnloFXFX_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4a_017_realistic_v14-v1-35a58109e00c38928fe6fe04f08bafb3/USER',
+#    '/GluGluHToMuMu_M125_TuneCP5_PSweights_13TeV_amcatnloFXFX_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4i_017_realistic_v14-v1-35a58109e00c38928fe6fe04f08bafb3/USER',
+#    '/GluGluHToMuMu_M125_TuneCP5_PSweights_13TeV_amcatnloFXFX_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4i_ealistic_v14_ext1-v1-35a58109e00c38928fe6fe04f08bafb3/USER'
+    '/GluGluHToMuMu_M125_TuneCP5_PSweights_13TeV_amcatnloFXFX_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV8a_ealistic_v14_ext1-v1-ef4ff047883fc7dcd360f5fd3b961f3e/USER',
+    '/GluGluHToMuMu_M125_TuneCP5_PSweights_13TeV_amcatnloFXFX_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV8a_017_realistic_v14-v1-ef4ff047883fc7dcd360f5fd3b961f3e/USER',
+    '/GluGluHToMuMu_M125_13TeV_amcatnloFXFX_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV8a_017_realistic_v14-v1-ef4ff047883fc7dcd360f5fd3b961f3e/USER',
+],
+"ggHmm_2017POWPY"       : [
+#    '/GluGluHToMuMu_M-125_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4i_017_realistic_v14-v1-35a58109e00c38928fe6fe04f08bafb3/USER',
+#    '/GluGluHToMuMu_M-125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4i_017_realistic_v14-v1-35a58109e00c38928fe6fe04f08bafb3/USER',
+#    '/GluGluHToMuMu_M-125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4_ealistic_v14_ext1-v1-35a58109e00c38928fe6fe04f08bafb3/USER'
+    '/GluGluHToMuMu_M-125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV8a_ealistic_v14_ext1-v1-ef4ff047883fc7dcd360f5fd3b961f3e/USER',
+    '/GluGluHToMuMu_M-125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV8a_017_realistic_v14-v1-ef4ff047883fc7dcd360f5fd3b961f3e/USER',
+    '/GluGluHToMuMu_M-125_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV8a_017_realistic_v14-v1-ef4ff047883fc7dcd360f5fd3b961f3e/USER',
+],
+
+
+"vbfHmm_2017POWPY"      : [
+#    '/VBFHToMuMu_M-125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4e_017_realistic_v14-v1-35a58109e00c38928fe6fe04f08bafb3/USER'
+    '/VBFHToMuMu_M-125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV8a_017_realistic_v14-v1-ef4ff047883fc7dcd360f5fd3b961f3e/USER',
+],
+"vbfHmm_2017AMCPY"      : [
+#    '/VBFHToMuMu_M125_13TeV_amcatnlo_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4b_017_realistic_v14-v1-35a58109e00c38928fe6fe04f08bafb3/USER',
+#    '/VBFHToMuMu_M125_TuneCP5_PSweights_13TeV_amcatnlo_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4i_017_realistic_v14-v1-35a58109e00c38928fe6fe04f08bafb3/USER'
+    '/VBFHToMuMu_M125_TuneCP5_PSweights_13TeV_amcatnlo_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV8a_ealistic_v14_ext1-v1-ef4ff047883fc7dcd360f5fd3b961f3e/USER',
+    '/VBFHToMuMu_M125_TuneCP5_PSweights_13TeV_amcatnlo_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV8a_017_realistic_v14-v1-ef4ff047883fc7dcd360f5fd3b961f3e/USER',
+    '/VBFHToMuMu_M125_13TeV_amcatnlo_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV8a_017_realistic_v14-v1-ef4ff047883fc7dcd360f5fd3b961f3e/USER',
+],
+"vbfHmm_2017AMCHERWIG"  : [
+#    '/VBFHToMuMu_M-125_TuneEEC5_13TeV-amcatnlo-herwigpp/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4i_017_realistic_v14-v1-35a58109e00c38928fe6fe04f08bafb3/USER'
+    '/VBFHToMuMu_M-125_TuneEEC5_13TeV-amcatnlo-herwigpp/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV8a_017_realistic_v14-v1-ef4ff047883fc7dcd360f5fd3b961f3e/USER',
+],
+"vbfHmm_2017POWHERWIG"  : [
+#    '/VBFHToMuMu_M-125_TuneEEC5_13TeV-powheg-herwigpp/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4b_017_realistic_v14-v1-35a58109e00c38928fe6fe04f08bafb3/USER'
+    '/VBFHToMuMu_M-125_TuneEEC5_13TeV-powheg-herwigpp/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV8a_017_realistic_v14-v1-ef4ff047883fc7dcd360f5fd3b961f3e/USER',
+],
+
+"zHmm_2017POWPY"        : [
+#    '/ZH_HToMuMu_ZToAll_M125_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4a_017_realistic_v14-v1-35a58109e00c38928fe6fe04f08bafb3/USER'
+    '/ZH_HToMuMu_ZToAll_M125_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV8a_017_realistic_v14-v1-ef4ff047883fc7dcd360f5fd3b961f3e/USER',
+],
+"ttHmm_2017POWPY"       : [
+#    '/ttHToMuMu_M125_TuneCP5_13TeV-powheg-pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4_017_realistic_v14-v3-35a58109e00c38928fe6fe04f08bafb3/USER',
+#    '/ttHToMuMu_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4_017_realistic_v14-v1-35a58109e00c38928fe6fe04f08bafb3/USER'
+    '/ttHToMuMu_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV8a_017_realistic_v14-v1-ef4ff047883fc7dcd360f5fd3b961f3e/USER',
+    '/ttHToMuMu_M125_TuneCP5_13TeV-powheg-pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV8a_017_realistic_v14-v3-ef4ff047883fc7dcd360f5fd3b961f3e/USER',
+],
+"WplusHmm_2017POWPY"    : [
+#    '/WplusH_HToMuMu_WToAll_M125_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4a_017_realistic_v14-v3-35a58109e00c38928fe6fe04f08bafb3/USER'
+    '/WplusH_HToMuMu_WToAll_M125_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV8a_017_realistic_v14-v3-ef4ff047883fc7dcd360f5fd3b961f3e/USER',
+],
+"WminusHmm_2017POWPY"   : [
+#    '/WminusH_HToMuMu_WToAll_M125_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4_017_realistic_v14-v1-35a58109e00c38928fe6fe04f08bafb3/USER'
+    '/WminusH_HToMuMu_WToAll_M125_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV8a_017_realistic_v14-v1-ef4ff047883fc7dcd360f5fd3b961f3e/USER',
+],
+"vbfHtautau_2017POWPY"  : [
+#    '/VBFHToTauTau_M125_13TeV_amcatnloFXFX_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV4_017_realistic_v14-v1-35a58109e00c38928fe6fe04f08bafb3/USER'
+],
+
+}
+
+
+
+
+
+
+
+

--- a/crab/datasets2018AndreaV7.py
+++ b/crab/datasets2018AndreaV7.py
@@ -1,0 +1,59 @@
+data2018 = {
+"SingleMuonRun2018A"     : [
+    '/SingleMuon/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdData2018ABC_NANOV4d_un2018A-17Sep2018-v2-c62fa4eac878db7eaebfd84006f0e75e/USER'
+],
+"SingleMuonRun2018B"     : [
+    '/SingleMuon/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdData2018ABC_NANOV4d_un2018B-17Sep2018-v1-c62fa4eac878db7eaebfd84006f0e75e/USER'
+],
+"SingleMuonRun2018C"     : [
+    '/SingleMuon/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdData2018ABC_NANOV4d_un2018C-17Sep2018-v1-c62fa4eac878db7eaebfd84006f0e75e/USER'
+],
+"SingleMuonRun2018D"     : [
+    '/SingleMuon/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdData2018D_NANOV4d_un2018D-22Jan2019-v2-7a3e88d5f53fe32949a96cea99d3e905/USER'
+],
+}
+
+
+mc2018 = {
+
+
+
+"ggHmm_2018AMCPY"       : [
+    "/GluGluHToMuMu_M125_TuneCP5_PSweights_13TeV_amcatnloFXFX_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2018_NANOV7a_018_realistic_v15-v2-20a85ef4c1e9f2ae0c33407d53453294/USER"
+],
+"ggHmm_2018POWPY"       : [
+    '/GluGluHToMuMu_M-125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2018_NANOV7a_018_realistic_v15-v2-20a85ef4c1e9f2ae0c33407d53453294/USER',
+    '/GluGluHToMuMu_M-125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2018_NANOV7a_ealistic_v15_ext1-v1-20a85ef4c1e9f2ae0c33407d53453294/USER'
+],
+
+"vbfHmm_2018POWPY"      : [
+    '/VBFHToMuMu_M-125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2018_NANOV7a_018_realistic_v15-v1-20a85ef4c1e9f2ae0c33407d53453294/USER',
+    '/VBFHToTauTau_M125_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2018_NANOV7a_ealistic_v15_ext1-v1-20a85ef4c1e9f2ae0c33407d53453294/USER'
+],
+"vbfHmm_2018AMCPY"      : [
+    "/VBFHToMuMu_M125_TuneCP5_PSweights_13TeV_amcatnlo_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2018_NANOV7a_018_realistic_v15-v2-20a85ef4c1e9f2ae0c33407d53453294/USER"
+],
+
+
+"zHmm_2018POWPY"        : [
+    '/ZH_HToMuMu_ZToAll_M125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2018_NANOV7a_018_realistic_v15-v2-20a85ef4c1e9f2ae0c33407d53453294/USER'
+],
+"ttHmm_2018POWPY"       : [
+    '/ttHToMuMu_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2018_NANOV7a_018_realistic_v15-v2-20a85ef4c1e9f2ae0c33407d53453294/USER'
+],
+"WplusHmm_2018POWPY"    : [
+    '/WplusH_HToMuMu_WToAll_M125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2018_NANOV7a_018_realistic_v15-v2-20a85ef4c1e9f2ae0c33407d53453294/USER'
+],
+"WminusHmm_2018POWPY"   : [
+    '/WminusH_HToMuMu_WToAll_M125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2018_NANOV7a_018_realistic_v15-v2-20a85ef4c1e9f2ae0c33407d53453294/USER'
+],
+#"vbfHtautau_2018POWPY"  : [
+    #"/VBFHToTauTau_M125_13TeV_powheg_pythia8/RunIIAutumn18NanoAODv5-Nano1June2019_102X_upgrade2018_realistic_v19_ext1-v1/NANOAODSIM"
+#],
+}
+
+
+
+
+
+

--- a/crab/datasets2018NANOv6.py
+++ b/crab/datasets2018NANOv6.py
@@ -1,0 +1,248 @@
+data2018 = {
+"SingleMuonRun2018A"     : [
+    '/SingleMuon/Run2018A-Nano25Oct2019-v1/NANOAOD'
+],
+"SingleMuonRun2018B"     : [
+    '/SingleMuon/Run2018B-Nano25Oct2019-v1/NANOAOD'
+],
+"SingleMuonRun2018C"     : [
+    '/SingleMuon/Run2018C-Nano25Oct2019-v1/NANOAOD'
+],
+"SingleMuonRun2018D"     : [
+    '/SingleMuon/Run2018D-Nano25Oct2019_ver2-v1/NANOAOD'
+],
+}
+
+
+
+mc2018 = {
+"DY105_2018AMCPY"     : [
+    '/DYJetsToLL_M-105To160_TuneCP5_PSweights_13TeV-amcatnloFXFX-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM'
+],
+"DY105_2018MGPY"      : [
+    "/DYJetsToLL_M-105To160_TuneCP5_PSweights_13TeV-madgraphMLM-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM"
+],
+"DY105VBF_2018AMCPY"  : [
+    '/DYJetsToLL_M-105To160_VBFFilter_TuneCP5_PSweights_13TeV-amcatnloFXFX-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_VBFPostMGFilter_102X_upgrade2018_realistic_v20-v1/NANOAODSIM',
+    '/DYJetsToLL_M-105To160_VBFFilter_TuneCP5_PSweights_13TeV-amcatnloFXFX-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_VBFPostMGFilter_102X_upgrade2018_realistic_v20_ext1-v1/NANOAODSIM'
+
+],
+"DY105VBF_2018MGPY"   : [
+    "/DYJetsToLL_M-105To160_VBFFilter_TuneCP5_PSweights_13TeV-madgraphMLM-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_VBFPostMGFilter_102X_upgrade2018_realistic_v20-v1/NANOAODSIM"
+],
+
+"DY0J_2018AMCPY"  : [
+    '/DYJetsToLL_0J_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM'
+],
+"DY1J_2018AMCPY"  : [
+    '/DYJetsToLL_1J_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM'
+],
+"DY2J_2018AMCPY"  : [
+    '/DYJetsToLL_2J_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM'
+],
+"DYM50_2018AMCPY" : [
+    "/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM", 
+    "/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20_ext2-v1/NANOAODSIM"
+],
+
+
+"DY1J_2018MGPY"  : [
+    '/DY1JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM'
+],
+"DY2J_2018MGPY"  : [
+    '/DY2JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM'
+],
+"DY3J_2018MGPY"  : [
+    '/DY3JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM'
+],
+"DY4J_2018MGPY"  : [
+    '/DY4JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM'
+],
+
+
+"EWKZ_2018MGHERWIG"         : [
+    '/EWK_LLJJ_MLL-50_MJJ-120_TuneCH3_PSweights_13TeV-madgraph-herwig7/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM'
+],
+"EWKZ_2018MGPY"             : [
+    "/EWK_LLJJ_MLL-50_MJJ-120_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM"
+],
+"EWKZint_2018MGPY"          : [
+    '/LLJJ_INT_SM_5f_LO_TuneCP5_PSweights_13TeV_madgraph-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM'
+],
+"EWKZ105_2018MGHERWIG"      : [
+    '/EWK_LLJJ_MLL_105-160_SM_5f_LO_TuneCH3_13TeV-madgraph-herwig7/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM'
+],
+"EWKZ105_2018MGPY"      : [
+    '/EWK_LLJJ_MLL_105-160_SM_5f_LO_TuneCP5_PSweights_13TeV-madgraph-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM'
+],
+
+
+
+
+
+"STs_2018AMCPY"             : [
+    '/ST_s-channel_4f_leptonDecays_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20_ext1-v1/NANOAODSIM'
+],
+"STstbar_2018POWPY"             : [
+    '/ST_s-channel_antitop_leptonDecays_13TeV-PSweights_powheg-pythia/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM'
+],
+"STst_2018POWPY"             : [
+    '/ST_s-channel_top_leptonDecays_13TeV-PSweights_powheg-pythia/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM'
+],
+"STwtbar_2018POWPY"         : [
+    '/ST_tW_antitop_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20_ext1-v1/NANOAODSIM'
+],
+"STwt_2018POWPY"            : [
+    '/ST_tW_top_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20_ext1-v1/NANOAODSIM'
+],
+"STtbar_2018POWPY"          : [
+    '/ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM'
+],
+"STt_2018POWPY"             : [
+    '/ST_t-channel_top_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM'
+],
+
+
+"TT_2018AMCPY"      : [
+    '/TTJets_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20_ext1-v1/NANOAODSIM',
+    '/TTJets_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20_ext2-v1/NANOAODSIM'
+],
+"TT_2018MGPY"       : [
+    "/TTJets_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM"
+],
+"TTlep_2018POWPY"   : [
+    '/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM'
+],
+"TTsemi_2018POWPY"  : [
+    '/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM',
+    '/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20_ext3-v1/NANOAODSIM'
+],
+"TThad_2018POWPY"   : [
+    #"/TTToHadronic_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM"
+    "/TTToHadronic_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20_ext2-v1/NANOAODSIM",
+    "/TTToHadronic_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v3/NANOAODSIM",
+],
+
+
+
+
+
+"W2J_2018AMCPY"  : [
+    "/WJetsToLNu_2J_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM"
+],
+"W1J_2018AMCPY"  : [
+    "/WJetsToLNu_1J_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM"
+],
+"W0J_2018AMCPY"  : [
+    "/WJetsToLNu_0J_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM"
+],
+
+
+
+"WWdps_2018MGPY"             : [
+    "/WWTo2L2Nu_DoubleScattering_13TeV-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM"
+],
+"WWdps_2018MGHERWIG"             : [
+    "/WWTo2L2Nu_DoubleScattering_TuneCH3_13TeV-herwig7/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM"
+],
+"WWJJlnln_2018MGPY"          : [
+    "/WWJJToLNuLNu_EWK_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20_ext1-v1/NANOAODSIM"
+],
+"WLLJJln_2018MG_MADSPIN_PY"  : [
+    "/WLLJJ_WToLNu_EWK_TuneCP5_13TeV_madgraph-madspin-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM"
+],
+"WWJJlnlnNoT_2018MGPY"       : [
+    "/WWJJToLNuLNu_EWK_noTop_13TeV-madgraph-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20_ext1-v1/NANOAODSIM"
+],
+
+
+
+
+
+
+"WW2l2n_2018POWPY"          : [
+    "/WWTo2L2Nu_NNPDF31_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM"
+],
+"WWlnqq_2018POWPY"          : [
+    '/WWToLNuQQ_NNPDF31_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM'
+],
+"WWlnqq_2018AMCPY"          : [
+    '/WWTo1L1Nu2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM'
+],
+
+
+"WZ1l3n_2018AMCPY"              : [
+    '/WZTo1L3Nu_13TeV_amcatnloFXFX_madspin_pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM'
+],
+"WZ2l2q_2018AMC_MADSPIN_PY"     : [
+    '/WZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM'
+],
+"WZ3l1n_2018POWPY"              : [
+    '/WZTo3LNu_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20_ext1-v1/NANOAODSIM'
+],
+"WZ3l1n_2018AMCPY"              : [
+    "/WZTo3LNu_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM",
+    "/WZTo3LNu_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20_ext1-v1/NANOAODSIM"
+],
+
+
+
+
+
+
+
+"ZZ2l2n_2018POWPY": [
+    "/ZZTo2L2Nu_TuneCP5_13TeV_powheg_pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20_ext1-v1/NANOAODSIM", 
+    "/ZZTo2L2Nu_TuneCP5_13TeV_powheg_pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20_ext2-v1/NANOAODSIM"
+],
+"ZZ2l2q_2018POWPY": [
+    '/ZZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM'
+],
+"ZZ4l_2018POWPY": [
+    "/ZZTo4L_TuneCP5_13TeV_powheg_pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20_ext1-v1/NANOAODSIM", 
+    "/ZZTo4L_TuneCP5_13TeV_powheg_pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20_ext2-v1/NANOAODSIM"
+],
+
+
+
+"ggHmm_2018AMCPY"       : [
+    "/GluGluHToMuMu_M125_TuneCP5_PSweights_13TeV_amcatnloFXFX_pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM"
+],
+"ggHmm_2018POWPY"       : [
+    '/GluGluHToMuMu_M-125_TuneCP5_PSweights_13TeV_powheg_pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM',
+    '/GluGluHToMuMu_M-125_TuneCP5_PSweights_13TeV_powheg_pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20_ext1-v1/NANOAODSIM'
+],
+
+"vbfHmm_2018POWPY"      : [
+    '/VBFHToMuMu_M-125_TuneCP5_PSweights_13TeV_powheg_pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM'
+],
+"vbfHmm_2018AMCPY"      : [
+    "/VBFHToMuMu_M125_TuneCP5_PSweights_13TeV_amcatnlo_pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM"
+],
+
+
+"zHmm_2018POWPY"        : [
+    '/ZH_HToMuMu_ZToAll_M125_TuneCP5_PSweights_13TeV_powheg_pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM'
+],
+"ttHmm_2018POWPY"       : [
+    '/ttHToMuMu_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM'
+],
+"WplusHmm_2018POWPY"    : [
+    '/WplusH_HToMuMu_WToAll_M125_TuneCP5_PSweights_13TeV_powheg_pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM'
+],
+"WminusHmm_2018POWPY"   : [
+    '/WminusH_HToMuMu_WToAll_M125_TuneCP5_PSweights_13TeV_powheg_pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM'
+],
+"vbfHtautau_2018POWPY"  : [
+    "/VBFHToTauTau_M125_13TeV_powheg_pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20_ext1-v1/NANOAODSIM"
+],
+}
+
+
+
+
+
+
+
+
+

--- a/crab/datasets2018andreaGeoFit.py
+++ b/crab/datasets2018andreaGeoFit.py
@@ -1,0 +1,48 @@
+data2018 = {
+"SingleMuonRun2018A"     : [],
+}
+
+
+mc2018 = {
+"ggHmm_2018AMCPY"       : [
+    #"/GluGluHToMuMu_M125_TuneCP5_PSweights_13TeV_amcatnloFXFX_pythia8/RunIIAutumn18NanoAODv5-Nano1June2019_102X_upgrade2018_realistic_v19-v1/NANOAODSIM"
+    '/GluGluHToMuMu_M125_TuneCP5_PSweights_13TeV_amcatnloFXFX_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2018_NANOV8a_018_realistic_v15-v2-f46cb006ca3922cbc5562884b4809ef9/USER',
+],
+"ggHmm_2018POWPY"       : [
+#    '/GluGluHToMuMu_M-125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2018_NANOV4c_ealistic_v15_ext1-v1-f77ac490c2015e446b4336e158bd70bc/USER',
+#    '/GluGluHToMuMu_M-125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2018_NANOV4c_018_realistic_v15-v2-f77ac490c2015e446b4336e158bd70bc/USER'
+    '/GluGluHToMuMu_M-125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2018_NANOV8a_ealistic_v15_ext1-v1-f46cb006ca3922cbc5562884b4809ef9/USER',
+    '/GluGluHToMuMu_M-125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2018_NANOV8a_018_realistic_v15-v2-f46cb006ca3922cbc5562884b4809ef9/USER',],
+
+"vbfHmm_2018POWPY"      : [
+#    '/VBFHToMuMu_M-125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2018_NANOV4c_018_realistic_v15-v1-f77ac490c2015e446b4336e158bd70bc/USER'
+    '/VBFHToMuMu_M-125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2018_NANOV8a_018_realistic_v15-v1-f46cb006ca3922cbc5562884b4809ef9/USER',
+],
+"vbfHmm_2018AMCPY"      : [
+    #"/VBFHToMuMu_M125_TuneCP5_PSweights_13TeV_amcatnlo_pythia8/RunIIAutumn18NanoAODv5-Nano1June2019_102X_upgrade2018_realistic_v19-v1/NANOAODSIM"
+    '/VBFHToMuMu_M125_TuneCP5_PSweights_13TeV_amcatnlo_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2018_NANOV8a_018_realistic_v15-v2-f46cb006ca3922cbc5562884b4809ef9/USER',
+],
+
+
+"zHmm_2018POWPY"        : [
+#    '/ZH_HToMuMu_ZToAll_M125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2018_NANOV4c_018_realistic_v15-v2-f77ac490c2015e446b4336e158bd70bc/USER'
+    '/ZH_HToMuMu_ZToAll_M125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2018_NANOV8a_018_realistic_v15-v2-f46cb006ca3922cbc5562884b4809ef9/USER',
+],
+"ttHmm_2018POWPY"       : [
+#    '/ttHToMuMu_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2018_NANOV4g_018_realistic_v15-v2-f77ac490c2015e446b4336e158bd70bc/USER'
+    '/ttHToMuMu_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2018_NANOV8a_018_realistic_v15-v2-f46cb006ca3922cbc5562884b4809ef9/USER',
+],
+"WplusHmm_2018POWPY"    : [
+#    '/WplusH_HToMuMu_WToAll_M125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2018_NANOV4g_018_realistic_v15-v2-f77ac490c2015e446b4336e158bd70bc/USER'
+    '/WplusH_HToMuMu_WToAll_M125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2018_NANOV8a_018_realistic_v15-v2-f46cb006ca3922cbc5562884b4809ef9/USER',
+],
+"WminusHmm_2018POWPY"   : [
+#    '/WminusH_HToMuMu_WToAll_M125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2018_NANOV4c_018_realistic_v15-v2-f77ac490c2015e446b4336e158bd70bc/USER'
+    '/WminusH_HToMuMu_WToAll_M125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2018_NANOV8a_018_realistic_v15-v2-f46cb006ca3922cbc5562884b4809ef9/USER',
+],
+"vbfHtautau_2018POWPY"  : [
+    #"/VBFHToTauTau_M125_13TeV_powheg_pythia8/RunIIAutumn18NanoAODv5-Nano1June2019_102X_upgrade2018_realistic_v19_ext1-v1/NANOAODSIM"
+    '/VBFHToTauTau_M125_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2018_NANOV8a_ealistic_v15_ext1-v1-f46cb006ca3922cbc5562884b4809ef9/USER',
+],
+}
+

--- a/crab/datasetsGeoFit.py
+++ b/crab/datasetsGeoFit.py
@@ -1,0 +1,164 @@
+data2016 = {
+"SingleMuonRun2016"     : [
+    '/SingleMuon/arizzi-RunIIData17_FSRNANO2016DATAV8a_un2016B-17Jul2018_ver2-v1-e1d5ff1146bf70dd49f0ee0edf6761a1/USER',
+    '/SingleMuon/arizzi-RunIIData17_FSRNANO2016DATAV8a_Run2016C-17Jul2018-v1-e1d5ff1146bf70dd49f0ee0edf6761a1/USER',
+    '/SingleMuon/arizzi-RunIIData17_FSRNANO2016DATAV8a_Run2016D-17Jul2018-v1-e1d5ff1146bf70dd49f0ee0edf6761a1/USER',
+    '/SingleMuon/arizzi-RunIIData17_FSRNANO2016DATAV8a_Run2016E-17Jul2018-v1-e1d5ff1146bf70dd49f0ee0edf6761a1/USER',
+    '/SingleMuon/arizzi-RunIIData17_FSRNANO2016DATAV8a_Run2016F-17Jul2018-v1-e1d5ff1146bf70dd49f0ee0edf6761a1/USER',
+    '/SingleMuon/arizzi-RunIIData17_FSRNANO2016DATAV8a_Run2016G-17Jul2018-v1-e1d5ff1146bf70dd49f0ee0edf6761a1/USER',
+    '/SingleMuon/arizzi-RunIIData17_FSRNANO2016DATAV8a_Run2016H-17Jul2018-v1-e1d5ff1146bf70dd49f0ee0edf6761a1/USER'
+],
+}
+
+
+
+data2017 = {
+"SingleMuonRun2017"     : [
+    "/SingleMuon/arizzi-RunIIData17_FSRmyNanoProdData2017_NANOV8a_Run2017B-31Mar2018-v1-45e86d7295e314a33531f898d6a9e6d9/USER", 
+    "/SingleMuon/arizzi-RunIIData17_FSRmyNanoProdData2017_NANOV8a_Run2017C-31Mar2018-v1-45e86d7295e314a33531f898d6a9e6d9/USER",
+    "/SingleMuon/arizzi-RunIIData17_FSRmyNanoProdData2017_NANOV8a_Run2017D-31Mar2018-v1-45e86d7295e314a33531f898d6a9e6d9/USER", 
+    "/SingleMuon/arizzi-RunIIData17_FSRmyNanoProdData2017_NANOV8a_Run2017E-31Mar2018-v1-45e86d7295e314a33531f898d6a9e6d9/USER", 
+    "/SingleMuon/arizzi-RunIIData17_FSRmyNanoProdData2017_NANOV8a_Run2017F-31Mar2018-v1-45e86d7295e314a33531f898d6a9e6d9/USER"
+],
+}
+
+
+
+
+
+data2018 = {
+"SingleMuonRun2018A"     : [
+    '/SingleMuon/arizzi-RunIIData17_FSRmyNanoProdData2018ABC_NANOV8a_Run2018A-17Sep2018-v2-7588eb9be3ff4881e5f8a164f5dbe1e9/USER'
+],
+"SingleMuonRun2018B"     : [
+    '/SingleMuon/arizzi-RunIIData17_FSRmyNanoProdData2018ABC_NANOV8a_Run2018B-17Sep2018-v1-7588eb9be3ff4881e5f8a164f5dbe1e9/USER'
+],
+"SingleMuonRun2018C"     : [
+    '/SingleMuon/arizzi-RunIIData17_FSRmyNanoProdData2018ABC_NANOV8a_Run2018C-17Sep2018-v1-7588eb9be3ff4881e5f8a164f5dbe1e9/USER'
+],
+"SingleMuonRun2018D"     : [
+    '/SingleMuon/arizzi-RunIIData17_FSRmyNanoProdData2018D_NANOV8a_Run2018D-22Jan2019-v2-da2477e625d6c56951b87c2abe489fc5/USER'
+],
+}
+
+mc2016 = {
+
+"EWKZ105_2016MGHERWIG"       : [
+    #"/EWK_LLJJ_MLL_105-160_ptJ-0_SM_5f_LO_TuneEEC5_13TeV-madgraph-herwigpp/arizzi-RunIISummer16MiniAODv3_FSRNANO2016MCV8a_bcad356ea4ed7e4f08b4-402030b838330283a01886ce39c7d12e/USER"
+    "/EWK_LLJJ_MLL_105-160_ptJ-0_SM_5f_LO_TuneEEC5_13TeV-madgraph-herwigpp/arizzi-RunIISummer16MiniAODv3_FSRNANO2016MCV8b_bcad356ea4ed7e4f08b4-402030b838330283a01886ce39c7d12e/USER"
+],
+}
+
+
+
+mc2017 = {
+
+"EWKZ105_2017MGHERWIG"       : [
+    "/EWK_LLJJ_MLL_105-160_ptJ-0_SM_5f_LO_TuneEEC5_13TeV-madgraph-h7/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV8b_7a39ab0ed099ff55ceb9-ef4ff047883fc7dcd360f5fd3b961f3e/USER"
+],
+
+#"ggHmm_2017AMCPY"       : [
+    #'/GluGluHToMuMu_M125_13TeV_amcatnloFXFX_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV8a_017_realistic_v14-v1-ef4ff047883fc7dcd360f5fd3b961f3e/USER',
+    #'/GluGluHToMuMu_M125_TuneCP5_PSweights_13TeV_amcatnloFXFX_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV8a_017_realistic_v14-v1-ef4ff047883fc7dcd360f5fd3b961f3e/USER',
+    #'/GluGluHToMuMu_M125_TuneCP5_PSweights_13TeV_amcatnloFXFX_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV8a_ealistic_v14_ext1-v1-ef4ff047883fc7dcd360f5fd3b961f3e/USER'
+#],
+#"ggHmm_2017POWPY"       : [
+    #'/GluGluHToMuMu_M-125_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV8a_017_realistic_v14-v1-ef4ff047883fc7dcd360f5fd3b961f3e/USER',
+    #'/GluGluHToMuMu_M-125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV8a_017_realistic_v14-v1-ef4ff047883fc7dcd360f5fd3b961f3e/USER',
+    #'/GluGluHToMuMu_M-125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV8a_ealistic_v14_ext1-v1-ef4ff047883fc7dcd360f5fd3b961f3e/USER'
+#],
+
+
+
+#"vbfHmm_2017POWPY"      : [
+    #'/VBFHToMuMu_M-125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV8a_017_realistic_v14-v1-ef4ff047883fc7dcd360f5fd3b961f3e/USER'
+#],
+#"vbfHmm_2017AMCPY"      : [
+    #'/VBFHToMuMu_M125_13TeV_amcatnlo_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV8a_017_realistic_v14-v1-ef4ff047883fc7dcd360f5fd3b961f3e/USER',
+    #'/VBFHToMuMu_M125_TuneCP5_PSweights_13TeV_amcatnlo_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV8a_017_realistic_v14-v1-ef4ff047883fc7dcd360f5fd3b961f3e/USER',
+    #'/VBFHToMuMu_M125_TuneCP5_PSweights_13TeV_amcatnlo_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV8a_ealistic_v14_ext1-v1-ef4ff047883fc7dcd360f5fd3b961f3e/USER'
+#],
+#"vbfHmm_2017AMCHERWIG"  : [
+    #'/VBFHToMuMu_M-125_TuneEEC5_13TeV-amcatnlo-herwigpp/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV8a_017_realistic_v14-v1-ef4ff047883fc7dcd360f5fd3b961f3e/USER'
+#],
+#"vbfHmm_2017POWHERWIG"  : [
+    #'/VBFHToMuMu_M-125_TuneEEC5_13TeV-powheg-herwigpp/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV8a_017_realistic_v14-v1-ef4ff047883fc7dcd360f5fd3b961f3e/USER'
+#],
+
+#"zHmm_2017POWPY"        : [
+    #'/ZH_HToMuMu_ZToAll_M125_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV8a_017_realistic_v14-v1-ef4ff047883fc7dcd360f5fd3b961f3e/USER'
+#],
+#"ttHmm_2017POWPY"       : [
+    #'/ttHToMuMu_M125_TuneCP5_13TeV-powheg-pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV8a_017_realistic_v14-v3-ef4ff047883fc7dcd360f5fd3b961f3e/USER',
+    #'/ttHToMuMu_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV8a_017_realistic_v14-v1-ef4ff047883fc7dcd360f5fd3b961f3e/USER'
+#],
+#"WplusHmm_2017POWPY"    : [
+    #'/WplusH_HToMuMu_WToAll_M125_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV8a_017_realistic_v14-v3-ef4ff047883fc7dcd360f5fd3b961f3e/USER'
+#],
+#"WminusHmm_2017POWPY"   : [
+    #'/WminusH_HToMuMu_WToAll_M125_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV8a_017_realistic_v14-v1-ef4ff047883fc7dcd360f5fd3b961f3e/USER'
+#],
+#"vbfHtautau_2017POWPY"  : [
+    #''
+#],
+}
+
+
+
+
+
+
+mc2018 = {
+
+"EWKZ105_2018MGHERWIG"       : [
+    "/EWK_LLJJ_MLL_105-160_ptJ-0_SM_5f_LO_TuneEEC5_13TeV-madgraph-h7/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2018_NANOV8b_410aea6d0b4d52723d06-f46cb006ca3922cbc5562884b4809ef9/USER"
+],
+
+
+#"ggHmm_2018AMCPY"       : [
+    #"/GluGluHToMuMu_M125_TuneCP5_PSweights_13TeV_amcatnloFXFX_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2018_NANOV8a_018_realistic_v15-v2-f46cb006ca3922cbc5562884b4809ef9/USER"
+#],
+#"ggHmm_2018POWPY"       : [
+    #'/GluGluHToMuMu_M-125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2018_NANOV8a_018_realistic_v15-v2-f46cb006ca3922cbc5562884b4809ef9/USER',
+    #'/GluGluHToMuMu_M-125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2018_NANOV8a_ealistic_v15_ext1-v1-f46cb006ca3922cbc5562884b4809ef9/USER'
+#],
+
+
+
+#"vbfHmm_2018POWPY"      : [
+    #'/VBFHToMuMu_M-125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2018_NANOV8a_018_realistic_v15-v1-f46cb006ca3922cbc5562884b4809ef9/USER',
+#],
+#"vbfHmm_2018AMCPY"      : [
+    #"/VBFHToMuMu_M125_TuneCP5_PSweights_13TeV_amcatnlo_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2018_NANOV8a_018_realistic_v15-v2-f46cb006ca3922cbc5562884b4809ef9/USER"
+#],
+
+
+#"zHmm_2018POWPY"        : [
+    #'/ZH_HToMuMu_ZToAll_M125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2018_NANOV8a_018_realistic_v15-v2-f46cb006ca3922cbc5562884b4809ef9/USER'
+#],
+#"ttHmm_2018POWPY"       : [
+    #'/ttHToMuMu_M125_TuneCP5_PSweights_13TeV-powheg-pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2018_NANOV8a_018_realistic_v15-v2-f46cb006ca3922cbc5562884b4809ef9/USER'
+#],
+#"WplusHmm_2018POWPY"    : [
+    #'/WplusH_HToMuMu_WToAll_M125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2018_NANOV8a_018_realistic_v15-v2-f46cb006ca3922cbc5562884b4809ef9/USER'
+#],
+#"WminusHmm_2018POWPY"   : [
+    #'/WminusH_HToMuMu_WToAll_M125_TuneCP5_PSweights_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2018_NANOV8a_018_realistic_v15-v2-f46cb006ca3922cbc5562884b4809ef9/USER'
+#],
+#"vbfHtautau_2018POWPY"  : [
+    #"/VBFHToTauTau_M125_13TeV_powheg_pythia8/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2018_NANOV8a_ealistic_v15_ext1-v1-f46cb006ca3922cbc5562884b4809ef9/USER"
+#],
+}
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/crab/datasetsNew.py
+++ b/crab/datasetsNew.py
@@ -1,0 +1,35 @@
+data2016 = {
+"SingleMuonRun2016"     : [
+],
+"SingleMuonRun2017"     : [
+],
+"SingleMuonRun2018"     : [
+],
+}
+
+mc2016 = {
+#"EWKZ105FIX_2016MGHERWIG"     : [
+#    '/EWK_LLJJ_MLL_105-160_ptJ-0_SM_5f_LO_TuneEEC5_13TeV-madgraph-herwigpp/arizzi-RunIISummer16MiniAODv3_FSRNANO2016MCV8b_bcad356ea4ed7e4f08b4-402030b838330283a01886ce39c7d12e/USER'
+#],
+"EWKZ105FIX2_2016MGHERWIG"     : [
+    '/EWK_LLJJ_MLL_105-160_ptJ-0_SM_5f_LO_TuneEEC5_13TeV-madgraph-herwigpp/arizzi-RunIISummer16MiniAODv3_FSRNANO2016MCV8d_bcad356ea4ed7e4f08b4-402030b838330283a01886ce39c7d12e/USER'
+],
+}
+
+mc2017 = {
+#"EWKZ105FIX_2017MGHERWIG"     : [
+#    '/EWK_LLJJ_MLL_105-160_ptJ-0_SM_5f_LO_TuneEEC5_13TeV-madgraph-h7/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV8b_7a39ab0ed099ff55ceb9-ef4ff047883fc7dcd360f5fd3b961f3e/USER'
+#],
+"EWKZ105FIX2_2017MGHERWIG"     : [
+    '/EWK_LLJJ_MLL_105-160_ptJ-0_SM_5f_LO_TuneEEC5_13TeV-madgraph-h7/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2017_NANOV8d_7a39ab0ed099ff55ceb9-ef4ff047883fc7dcd360f5fd3b961f3e/USER'
+],
+}
+
+mc2018 = {
+#"EWKZ105FIX_2018MGHERWIG"     : [
+#    '/EWK_LLJJ_MLL_105-160_ptJ-0_SM_5f_LO_TuneEEC5_13TeV-madgraph-h7/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2018_NANOV8b_410aea6d0b4d52723d06-f46cb006ca3922cbc5562884b4809ef9/USER'
+#],
+"EWKZ105FIX2_2018MGHERWIG"     : [
+    '/EWK_LLJJ_MLL_105-160_ptJ-0_SM_5f_LO_TuneEEC5_13TeV-madgraph-h7/arizzi-RunIISummer16MiniAODv3_FSRmyNanoProdMc2018_NANOV8d_410aea6d0b4d52723d06-f46cb006ca3922cbc5562884b4809ef9/USER'
+],
+}


### PR DESCRIPTION
Summary of the datasets used in PROD_11_1 sent to Nan on 14/2

We used:
- data (2016, 2017, 2018)  our production (V8) with GeoFit (*)
https://github.com/gmandorl/nanoAOD-tools/blob/PROD_11_1/crab/datasetsGeoFit.py#L1-L42

- signal (2016, 2017, 2018) our production (V8) with GeoFit
https://github.com/gmandorl/nanoAOD-tools/blob/PROD_11_1/crab/datasets2016andreaGeoFit.py
https://github.com/gmandorl/nanoAOD-tools/blob/PROD_11_1/crab/datasets2017andreaGeoFit.py
https://github.com/gmandorl/nanoAOD-tools/blob/PROD_11_1/crab/datasets2018andreaGeoFit.py
- background (2016, 2018) from NANOv6
https://github.com/gmandorl/nanoAOD-tools/blob/PROD_11_1/crab/datasets2016NANOv6.py
https://github.com/gmandorl/nanoAOD-tools/blob/PROD_11_1/crab/datasets2018NANOv6.py

- background (2017) our production (V4) with PUID2017
https://github.com/gmandorl/nanoAOD-tools/blob/PROD_11_1/crab/datasets2017Andrea.py (*)

- we also ran on the special EWKZ105 (2016, 2017, 2018) from Andrea Marini. Our production (V8) with GeoFit
https://github.com/gmandorl/nanoAOD-tools/blob/PROD_11_1/crab/datasetsNew.py
